### PR TITLE
Add announce command

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -56,8 +56,8 @@ class utility(commands.Cog, name="utility"):
     @bridge.bridge_command(brief="Announce something!")
     @option("channel", discord.TextChannel, description="The channel to announce in")
     @option("message", str, description="The message to announce")
-    @option("embed", bool, description="Whether to make it an embed")
-    @option("attachment", discord.Attachment, description="A nice image")
+    @option("embed", bool, description="Whether to make it an embed", required=False, default=False)
+    @option("attachment", discord.Attachment, description="A nice image", required=False, default=None)
     @bridge.has_permissions(manage_guild=True)
     async def announce(self, ctx, channel: discord.TextChannel, message: str, embed: bool, attachment: discord.Attachment):
         """ Announce something in a channel """

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -57,23 +57,29 @@ class utility(commands.Cog, name="utility"):
     @option("channel", discord.TextChannel, description="The channel to announce in")
     @option("message", str, description="The message to announce")
     @option("embed", bool, description="Whether to make it an embed")
+    @option("attachment", discord.Attachment, description="A nice image")
     @bridge.has_permissions(manage_guild=True)
-    async def announce(self, ctx, channel: discord.TextChannel, message: str, embed):
+    async def announce(self, ctx, channel: discord.TextChannel, message: str, embed: bool, attachment: discord.Attachment):
         """ Announce something in a channel """
         if not channel.can_send():
             return await ctx.respond(f"I don't have permissions to send messages to {channel.mention}!", ephemeral=True)
         if embed:
-            print("bad")
             view = ConfirmView()
             await ctx.respond("Are you sure? Embeds don't actually send pings to any roles or users", view=view, ephemeral=True)
             await view.wait()
             if not view.confirmed:
                 return
         if not embed:
-            await channel.send(message)
+            if not attachment:
+                await channel.send(message)
+            else:
+                file = await attachment.to_file()
+                await channel.send(content=message, file=file)
         else:
-            embed = discord.Embed(colour=discord.Color.random(), description=message)
-            await channel.send(embed=embed)
+            message_embed = discord.Embed(colour=discord.Color.random(), description=message)
+            if attachment:
+                message_embed.set_thumbnail(url=attachment.url)
+            await channel.send(embed=message_embed)
         await ctx.respond("Message successfully sent!", ephemeral=True)
 
 

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -61,6 +61,7 @@ class utility(commands.Cog, name="utility"):
     @bridge.has_permissions(manage_guild=True)
     async def announce(self, ctx, channel: discord.TextChannel, message: str, embed: bool, attachment: discord.Attachment):
         """ Announce something in a channel """
+        await ctx.defer()
         if not channel.can_send():
             return await ctx.respond(f"I don't have permissions to send messages to {channel.mention}!", ephemeral=True)
         if embed:

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -88,6 +88,7 @@ class ConfirmView(discord.ui.View):
     def __init__(self):
         super().__init__(timeout=120)
         self.confirmed: bool = None
+        self.disable_on_timeout = True
 
     @discord.ui.button(label="Confirm", style=discord.ButtonStyle.green)
     async def confirm(self, button, interaction):

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -59,6 +59,7 @@ class utility(commands.Cog, name="utility"):
     @option("embed", bool, description="Whether to make it an embed")
     @bridge.has_permissions(manage_guild=True)
     async def announce(self, ctx, channel: discord.TextChannel, message: str, embed):
+        """ Announce something in a channel """
         if embed:
             view = ConfirmView()
             await ctx.respond("Are you sure? Embeds don't actually send pings to any roles or users", view=view, ephemeral=True)

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -60,24 +60,21 @@ class utility(commands.Cog, name="utility"):
     @bridge.has_permissions(manage_guild=True)
     async def announce(self, ctx, channel: discord.TextChannel, message: str, embed):
         """ Announce something in a channel """
+        if not channel.can_send():
+            return await ctx.respond(f"I don't have permissions to send messages to {channel.mention}!", ephemeral=True)
         if embed:
+            print("bad")
             view = ConfirmView()
             await ctx.respond("Are you sure? Embeds don't actually send pings to any roles or users", view=view, ephemeral=True)
             await view.wait()
             if not view.confirmed:
                 return
-        try:
-            if not embed:
-                await channel.send(message)
-            else:
-                embed = discord.Embed(colour=discord.Color.random(), description=message)
-                await channel.send(embed=embed)
-            if ctx.channel is not channel:
-                await ctx.respond("Message successfully sent!", ephemeral=True)
-        except Exception as e:
-            if str(e).startswith("403"):
-                e = "Missing Permissions"
-            await ctx.respond(f"Could not send message, `{e}`!\nMake sure I have view and write access in {channel.mention}", ephemeral=True)
+        if not embed:
+            await channel.send(message)
+        else:
+            embed = discord.Embed(colour=discord.Color.random(), description=message)
+            await channel.send(embed=embed)
+        await ctx.respond("Message successfully sent!", ephemeral=True)
 
 
 class ConfirmView(discord.ui.View):

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -83,7 +83,7 @@ class utility(commands.Cog, name="utility"):
 class ConfirmView(discord.ui.View):
     def __init__(self):
         super().__init__(timeout=120)
-        confirmed: bool = None
+        self.confirmed: bool = None
 
     @discord.ui.button(label="Confirm", style=discord.ButtonStyle.green)
     async def confirm(self, button, interaction):

--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -61,7 +61,7 @@ class utility(commands.Cog, name="utility"):
     @bridge.has_permissions(manage_guild=True)
     async def announce(self, ctx, channel: discord.TextChannel, message: str, embed: bool, attachment: discord.Attachment):
         """ Announce something in a channel """
-        await ctx.defer()
+        await ctx.defer(ephemeral=True)
         if not channel.can_send():
             return await ctx.respond(f"I don't have permissions to send messages to {channel.mention}!", ephemeral=True)
         if embed:


### PR DESCRIPTION
Including:
- Free choice of channel
- Permission check (of member as well as bot)
- Embed with random colors which supports all markdown
- Confirm popup if embed is selected due to missing ping functionality
- Use of many ephemeral messages so chat or bot channel stays clean
- Attachment in the form of an embed thumbnail or image attachment to pure text messages