### PR TITLE
Simplify free disk calculation

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -105,7 +105,7 @@ class Utility(discord.Cog, name="Utilities"):
         percent_used_ram = round(((ram.used / ram.total) * 100), 2)
         free_disk = round((disk_usage.free / divamount), 2)
         total_disk = round((disk_usage.total / divamount), 2)
-        percent_free_disk = round((((disk_usage.used / disk_usage.total * 100) - 100) * (-1)), 2)
+        percent_free_disk = round(disk_usage.free / disk_usage.total * 100, 2)
 
         embed = discord.Embed(color=utils.Colors.BLUE)
         embed.description = f"""


### PR DESCRIPTION
This simplifies the free disk calculation in the `/info` command by using `disk_usage.free` and other things.

Yes, this really is that small and useless of a PR, but it bugs me every time I look at it.