### PR TITLE
Use custom activity type instead of watching

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,7 +7,7 @@ import logger
 log = logger.get_logger(__name__)
 
 bot = discord.Bot(intents=discord.Intents.all(), status=Status.online,
-                  activity=Activity(type=ActivityType.watching, name="over the Paw Kingdom"))
+                  activity=Activity(type=ActivityType.custom, name="Watching over the Paw Kingdom"))
 
 bot.load_extensions("cogs")
 bot.load_extensions("cogs.events")


### PR DESCRIPTION
Discord now hides the activity type in a lot of places (for some reason), so Paw should use the custom type and just have `Watching` in the status itself